### PR TITLE
fix : force "https" on blade assets

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        If (env('APP_ENV') !== 'local') {
+            $this->app['request']->server->set('HTTPS', true);
+        }
+
+        Schema::defaultStringLength(191);
     }
 }


### PR DESCRIPTION
#1 
There is a problem with `asset`  function when it's loaded resources through `HTTP` protocol when the website was using `HTTPS`, which is caused the "Mixed content" problem on.

To fix that you need to add

```php
 \URL::forceScheme('https')
```
 into your AppServiceProvider file.